### PR TITLE
fix typos in `folke/lazy.nvim` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ return {
   dependencies = { "MunifTanjim/nui.nvim" },
   config = {
     keymaps = {
-      toggle = '<leader>dd' -- default '<leader>dd'
-      go_to_definition = '<leader>dx' default '<leader>dx'
+      toggle = '<leader>dd', -- default '<leader>dd'
+      go_to_definition = '<leader>dx' -- default '<leader>dx'
     }
   }
 }


### PR DESCRIPTION
## 📃 Summary

Fixed a couple of typos in the `folke/lazy.nvim` install instructions
