### PR TITLE
Update installation instructions for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ use {
 <td>
 
 ```lua
--- No idea how to set dependency in vim-plug, pls let me know if you use it
--- You need to have "MunifTanjim/nui.nvim" as Dependency
-Plug "better-ts-errors.nvim", { "tag": "*" }
+-- vim-plug no longer handles dependencies between plugins and it's 
+-- up to the user to manually specify Plug commands for dependent plugins.
+-- https://github.com/junegunn/vim-plug/wiki/faq#managing-dependencies 
+Plug "MunifTanjim/nui.nvim"
+Plug "OlegGulevskyy/better-ts-errors.nvim"
 ```
 
 </td>


### PR DESCRIPTION
## 📃 Summary

This pull request updates the vim-plug installation instructions section of the README.

### Changes:

- Updated instructions to include the recommended dependency pattern for vim-plug
- Added an expository comment linking to the deprecation of vim-plug's experimental dependency resolution feature
- Removed the tag attribute as `better-ts-errors.nvim` does not currently define any release tags
  - This fixed an error when calling `:PlugInstall`
- Updated the vim-plug argument to fix plugin resolution
  - This also fixed an error when calling `:PlugInstall`
  - vim-plug was looking for `https://github.com/better-ts-errors.nvim` instead of `https://github.com/OlegGulevskyy/better-ts-errors.nvim`

## 📸 Preview

<img width="445" alt="image" src="https://github.com/user-attachments/assets/0e1373a7-8d7d-4c25-9ffc-86f710933d53">
